### PR TITLE
changed popup dimensions

### DIFF
--- a/lib/stripe_client.js
+++ b/lib/stripe_client.js
@@ -2,12 +2,12 @@ Stripe = {};
 
 Stripe.requestCredential = function (options, credentialRequestCompleteCallback) {
 
-    if (!credentialRequestCompleteCallback && typeof options === 'function') {
+    if (!credentialRequestCompleteCallback && typeof options === "function") {
         credentialRequestCompleteCallback = options;
         options = {};
     }
 
-    var config = ServiceConfiguration.configurations.findOne({service: 'stripe'});
+    var config = ServiceConfiguration.configurations.findOne({ service: "stripe" });
     if (!config) {
         credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError("Service not configured"));
         return;
@@ -15,19 +15,22 @@ Stripe.requestCredential = function (options, credentialRequestCompleteCallback)
 
     var credentialToken = Random.id();
     var mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
-    var display = mobile ? 'touch' : 'popup';
-    var scope = '';
+    var display = mobile ? "touch" : "popup";
+    var scope = "";
 
     if (options && options.requestPermissions) {
-        scope = options.requestPermissions.join(',');
+        scope = options.requestPermissions.join(",");
     }
 
     var loginUrl =
         'https://connect.stripe.com/oauth/authorize' +
             '?response_type=code' +
             '&client_id=' + config.appId +
+            '&scope=' + config.scope +
             '&redirect_uri=' + Meteor.absoluteUrl('_oauth/stripe?close=close') +
             '&state=' + credentialToken;
+
     var dimensions = { width: 650, height: 560 };
     Oauth.initiateLogin(credentialToken, loginUrl, credentialRequestCompleteCallback, dimensions);
+
 };


### PR DESCRIPTION
The login page for Stripe has a larger height than the one of the default popup Meteor provides for logging in with third-party accounts. Without setting it right, the Stripe "login" button is not visible unless the user scrolls in the popup.
