### PR TITLE
Should work decently

### DIFF
--- a/lib/accounts_stripe.js
+++ b/lib/accounts_stripe.js
@@ -1,23 +1,21 @@
-Accounts.oauth.registerService('stripe');
+Accounts
+  .oauth
+  .registerService('stripe');
 
 if (Meteor.isClient) {
-    Meteor.loginWithStripe = function(options, callback) {
-        // support a callback without options
-        if (! callback && typeof options === "function") {
-            callback = options;
-            options = null;
-        }
+  Meteor.loginWithStripe = function(options, callback) {
+    // support a callback without options
+    if (!callback && typeof options === "function") {
+      callback = options;
+      options = null;
+    }
 
-        var credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);
-        StripeOAuth.requestCredential(options, credentialRequestCompleteCallback);
-    };
+    var credentialRequestCompleteCallback = Accounts.oauth
+      .credentialRequestCompleteHandler(callback);
+    StripeOauth.requestCredential(options, credentialRequestCompleteCallback);
+  };
 } else {
-    Accounts.addAutopublishFields({
-        forLoggedInUser: ['services.stripe'],
-        forOtherUsers: [
-            'services.stripe.id',
-            'services.stripe.firstName',
-            'services.stripe.lastName'
-        ]
-    });
+  Accounts.addAutopublishFields({
+    forLoggedInUser: ['services.stripe']
+  });
 }

--- a/lib/stripe_client.js
+++ b/lib/stripe_client.js
@@ -1,36 +1,35 @@
-StripeOAuth = {};
+StripeOauth = {};
 
-StripeOAuth.requestCredential = function (options, credentialRequestCompleteCallback) {
+StripeOauth.requestCredential = function (options, credentialRequestCompleteCallback) {
 
-    if (!credentialRequestCompleteCallback && typeof options === "function") {
+    if (!credentialRequestCompleteCallback && typeof options === 'function') {
         credentialRequestCompleteCallback = options;
         options = {};
     }
 
-    var config = ServiceConfiguration.configurations.findOne({ service: "stripe" });
+    var config = ServiceConfiguration.configurations.findOne({ service: 'stripe' });
     if (!config) {
-        credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError("Service not configured"));
+        credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError());
         return;
     }
 
     var credentialToken = Random.id();
-    var mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
-    var display = mobile ? "touch" : "popup";
-    var scope = "";
-
-    if (options && options.requestPermissions) {
-        scope = options.requestPermissions.join(",");
-    }
+    var loginStyle = OAuth._loginStyle('stripe', config, options);
+    var prefill = options && options.prefill ? '&' + $.param(options.prefill) : '';
 
     var loginUrl =
         'https://connect.stripe.com/oauth/authorize' +
             '?response_type=code' +
             '&client_id=' + config.appId +
             '&scope=' + config.scope +
-            '&redirect_uri=' + Meteor.absoluteUrl('_oauth/stripe?close') +
-            '&state=' + credentialToken;
+            '&state=' + OAuth._stateParam(loginStyle, credentialToken) +
+            prefill;
 
-    var dimensions = { width: 650, height: 560 };
-    Oauth.initiateLogin(credentialToken, loginUrl, credentialRequestCompleteCallback, dimensions);
-
+    OAuth.launchLogin({
+      loginService: 'stripe',
+      loginStyle: loginStyle,
+      loginUrl: loginUrl,
+      credentialRequestCompleteCallback: credentialRequestCompleteCallback,
+      credentialToken: credentialToken
+    });
 };

--- a/lib/stripe_server.js
+++ b/lib/stripe_server.js
@@ -1,86 +1,94 @@
-StripeOAuth = {};
+StripeOauth = {};
 
 Oauth.registerService('stripe', 2, null, function(query) {
+  var tokenResponse = getTokenResponse(query);
+  var accessToken = tokenResponse.accessToken;
+  var refreshToken = tokenResponse.refreshToken;
 
-    var response    = getTokenResponse(query);
-    var accessToken = response.accessToken;
-		
-		
-    var serviceData = {
-        accessToken: accessToken,
-        stripe_publishable_key: response.stripe_publishable_key,
-        stripe_user_id: response.stripe_user_id
-        
-    };
+  var identity = getIdentity(tokenResponse.stripe_id);
+  var whitelisted = ['id', 'email', 'business_name', 'business_url', 'country', 'default_currency'];
 
-    var whiteListed = ['first_name', 'last_name'];
 
-    var fields = _.pick(whiteListed);
-    _.extend(serviceData, fields);
+  var serviceData = {
+    accessToken: OAuth.sealSecret(accessToken),
+    refreshToken: OAuth.sealSecret(refreshToken),
+    stripe_publishable_key: tokenResponse.stripe_publishable_key,
+  };
 
-    serviceData.id = serviceData.uid;
-    delete serviceData.uid;
+  var fields = _.pick(identity, whitelisted);
+  _.extend(serviceData, fields);
 
-    return {
-        serviceData: serviceData,
-        options: {
-            profile: {
-                profile: fields
-            }
-        }
-    };
+  return {
+    serviceData: serviceData,
+    options: {profile: {name: identity.business_name}}
+  };
 });
 
 // returns an object containing:
 // - accessToken
 // - expiresIn: lifetime of token in seconds
-var getTokenResponse = function (query) {
-    var config = ServiceConfiguration.configurations.findOne({service: 'stripe'});
-    if (!config) {
-        throw new ServiceConfiguration.ConfigError("Service not configured");
-    }
+var getTokenResponse = function(query) {
+  var config = ServiceConfiguration.configurations.findOne({service: 'stripe'});
+  if (!config) {
+    throw new ServiceConfiguration.ConfigError();
+  }
 
-    var responseContent;
+  var responseContent;
 
-    try {
-        // Request an access token
-        responseContent = HTTP.post(
-            "https://connect.stripe.com/oauth/token", {
-                params: {
-                    client_id:     config.appId,
-                    client_secret: config.secret,
-                    code:          query.code,
-                    grant_type: 	'authorization_code',
-                    redirect_uri: Meteor.absoluteUrl("_oauth/stripe?close")
-                }
-            }).content;
+  try {
+    // Request an access token
+    responseContent = HTTP.post('https://connect.stripe.com/oauth/token', {
+      params: {
+        client_secret: OAuth.openSecret(config.secret),
+        code: query.code,
+        grant_type: 'authorization_code'
+      }
+    }).content;
 
-    } catch (err) {
-        throw _.extend(new Error("Failed to complete OAuth handshake with stripe. " + err.message),
-            {response: err.response});
-    }
-    // Success!  Extract the stripe access token and key
-    // from the response
-    var parsedResponse = JSON.parse(responseContent);
+  } catch (err) {
+    throw _.extend(new Error("Failed to complete OAuth handshake with Stripe. " + err.message), {
+      response: err.response
+    });
+  }
+  // Success!  Extract the stripe access token and key
+  // from the response
+  var parsedResponse = JSON.parse(responseContent);
 
-    var stripeAccessToken = parsedResponse.access_token;
-    var stripe_id = parsedResponse.stripe_user_id;
-    var stripe_publishable_key = parsedResponse.stripe_publishable_key;
+  var stripeAccessToken = parsedResponse.access_token;
+  var stripeRefreshToken = parsedResponse.refresh_token;
+  var stripe_id = parsedResponse.stripe_user_id;
+  var stripe_publishable_key = parsedResponse.stripe_publishable_key;
 
-    if (!stripeAccessToken) {
-        throw new Error("Failed to complete OAuth handshake with stripe " +
-           "-- can't find access token in HTTP response. " + responseContent);
-    }
-    return {
-        accessToken: stripeAccessToken,
-        stripe_user_id: stripe_id,
-        stripe_publishable_key: stripe_publishable_key
-    };
+  if (!stripeAccessToken) {
+    throw new Error("Failed to complete OAuth handshake with Stripe " +
+      "-- can't find access token in HTTP response. " + responseContent);
+  }
+  return {
+    accessToken: stripeAccessToken,
+    refreshToken: stripeRefreshToken,
+    stripe_id: stripe_id,
+    stripe_publishable_key: stripe_publishable_key
+  };
 };
 
+var getIdentity = function(stripe_id) {
+  var config = ServiceConfiguration.configurations.findOne({service: 'stripe'});
+  if (!config) {
+    throw new ServiceConfiguration.ConfigError();
+  }
 
+  try {
+    return HTTP.get('https://api.stripe.com/v1/accounts/' + stripe_id, {
+      headers: {
+        Authorization: 'Bearer ' + config.secret,
+      }
+    }).data;
+  } catch (err) {
+    throw _.extend(new Error("Failed to fetch identity from Stripe. " + err.message),
+                   {response: err.response});
+  }
+};
 
-
-StripeOAuth.retrieveCredential = function(credentialToken) {
-    return Oauth.retrieveCredential(credentialToken);
+StripeOauth.retrieveCredential = function(credentialToken) {
+  return Oauth.retrieveCredential(credentialToken);
 };

--- a/package.js
+++ b/package.js
@@ -1,11 +1,12 @@
 Package.describe({
     summary: 'Login service for stripe accounts',
-    name: 'accounts-stripe'
+    name: 'mrt:accounts-stripe',
+    version: '0.0.3',
 });
 
 Package.onUse( function (api) {
-    api.versionsFrom('1.2'); 
-    if (api.export) api.export('StripeOAuth');     
+    api.versionsFrom('1.2');
+    if (api.export) api.export('StripeOAuth');
     api.use('accounts-base', ['client', 'server']);
     api.imply('accounts-base', ['client', 'server']);
     api.use('accounts-oauth', ['client', 'server']);
@@ -17,9 +18,11 @@ Package.onUse( function (api) {
     api.use('templating', 'client');
     api.use('random', 'client');
     api.use('service-configuration', ['client', 'server']);
-  	
+
+    api.export('StripeOauth');
+
   	api.addFiles(
-    ['lib/stripe_configure.html', 'lib/stripe_configure.js', 
+    ['lib/stripe_configure.html', 'lib/stripe_configure.js',
     'lib/stripe_login_button.css'],
     'client');
 


### PR DESCRIPTION
Hi - I’ve made several changes to the project, mimicking the official Meteor Facebook package while trying to be relevant to the Stripe OAuth and API.

To be used, you should configure your Stripe App as below server-side:

```
  Meteor.startup(function() {
    Accounts.loginServiceConfiguration.upsert({
      service: 'stripe'
        }, {
        $set: {
          service: 'stripe',
          appId: YOUR_STRIPE_CLIENT_ID,
          secret: YOUR_STRIPE_SECRET_KEY,
          loginStyle: 'redirect',
          scope: 'read_write' //or read_only
        }
      });
    }
  );
```

I prefer the loginStyle to be `redirect` but note that in that case the callback from `loginWithStripe` won’t work (this is the expected behavior).

Therefore, you can call `Meteor.loginWithStripe` simply as `Meteor.loginWithStripe()`.
